### PR TITLE
betting cog

### DIFF
--- a/cogs/betting.py
+++ b/cogs/betting.py
@@ -1,0 +1,202 @@
+import asyncio
+from collections import Counter
+
+import aiosqlite
+import discord
+from discord.ui import Select, View
+from discord.ext import commands, tasks
+
+import utils.econfuncs as econ
+
+bank = "./data/database.sqlite"
+
+class BetNotEnoughBal(Exception):
+    pass
+
+class BetNotRunning(Exception):
+    pass
+
+class BetModal(discord.ui.Modal, title='BetModal'):
+
+    def __init__(self, cog, index=0):
+        super().__init__()
+        self.cog = cog
+        self.index = index
+        self.option = self.cog.bet_options[index]
+        self.title = f"Betting on {self.option}"
+
+    amount = discord.ui.TextInput(
+        label='Amount',
+        placeholder='1',
+    )
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            value = int(self.amount.value)
+        except ValueError:
+            await interaction.response.send_message(f'{self.amount.value} is not a valid number', ephemeral=True)
+            return
+
+        if value <= 0:
+            await interaction.response.send_message(f'You cannot bet that amount', ephemeral=True)
+            return
+
+        try:
+            await self.cog.add_bet(interaction.user, self.index, value)
+        except BetNotEnoughBal:
+            await interaction.response.send_message(f'You do not have enough balance to make that bet', ephemeral=True)
+            return
+        except BetNotRunning:
+            await interaction.response.send_message(f'No bet is currently running', ephemeral=True)
+            return
+
+        await interaction.response.send_message(f'You have bet {value} on {self.option}', ephemeral=True)
+
+
+class Betting(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.bet_message = None
+        self.bet_view = None
+        self.bet_options = []
+        self.bet_values = []
+        self.update_bet.add_exception_type(asyncio.TimeoutError)
+        self.update_bet.add_exception_type(discord.errors.DiscordServerError)
+
+    def button_callback(self, index):
+        async def inner(interaction):
+            await interaction.response.send_modal(BetModal(self, index))
+        return inner
+
+    async def add_bet(self, user: discord.User | discord.Member, index: int, amount: int):
+        if not self.update_bet.is_running():
+            raise BetNotRunning("No bet is currently running")
+
+        value = self.bet_values[index]
+        if not user.id in value:
+            value[user.id] = 0
+
+        user_bal = await econ.get_bal(user)
+        if user_bal < amount:
+            raise BetNotEnoughBal("Not enough money to place bet")
+
+        option = self.bet_options[index]
+
+        await econ.update_amount(user, -amount, False, f"bet {amount} on {option}")
+        value[user.id] += amount
+
+    @commands.command()
+    @commands.is_owner()
+    async def createbet(self, ctx, *, options: str):
+        await ctx.message.delete()
+        if self.update_bet.is_running():
+            await ctx.send('a bet is still running', ephemeral=True)
+            return
+
+        """Create a poll for an event"""
+        self.bet_options = options.split(",")
+        self.bet_values = []
+        self.bet_view = discord.ui.View()
+
+        embed = discord.Embed(title="Betting")
+        for i, option in enumerate(self.bet_options):
+            item = discord.ui.Button(
+                style=discord.ButtonStyle.primary,
+                label=option
+            )
+            item.callback = self.button_callback(i)
+            self.bet_view.add_item(item)
+
+            embed.add_field(
+                name=option,
+                value=f"`0`",
+                inline=True
+            )
+            self.bet_values.append({})
+
+
+        self.bet_message = await ctx.send(embed=embed, view=self.bet_view)
+
+        self.update_bet.start()
+
+    @tasks.loop(seconds=10.0)
+    async def update_bet(self):
+        print("update bet")
+        if self.bet_message:
+            self.votes = Counter()  # Reset the votes counter at the beginning
+            cache_msg = await self.bet_message.channel.fetch_message(
+                self.bet_message.id
+            )
+
+            embed = discord.Embed(title="Betting")
+            for i, option in enumerate(self.bet_options):
+                val = sum(self.bet_values[i].values())
+                embed.add_field(
+                    name=option,
+                    value=f"`{val}`",
+                    inline=True
+                )
+            await self.bet_message.edit(embed=embed, view=self.bet_view)
+
+    @commands.command()
+    @commands.is_owner()
+    async def payoutbet(self, ctx, index: int):
+        await ctx.message.delete()
+        if self.update_bet.is_running():
+            await ctx.send("Bet is still running")
+            return
+
+        winner = index
+        option = self.bet_options[winner]
+
+        total_pot = 0
+        for a in self.bet_values:
+            for b in a.values():
+                total_pot += b
+
+        winner_pot = 0
+        # Calculate how big the winner pot was
+        for bal in self.bet_values[winner].values():
+            winner_pot += bal
+
+        for user_id, bal in self.bet_values[winner].items():
+            winnings = total_pot * (b / winner_pot)
+            user = await self.bot.fetch_user(user_id)
+            await econ.update_amount(user, winnings, False, f"won bet on {option}")
+
+        await ctx.send(f"{option} has won, winners have received their share of the payout")        
+
+    @commands.command()
+    @commands.is_owner()
+    async def cancelbet(self, ctx):
+        if self.update_bet.is_running():
+            await ctx.send("Bet is still running")
+            return
+
+        for index, value in enumerate(self.bet_values):
+            option = self.bet_options[index]
+            for user_id, amount in value.items():
+                user = await self.bot.fetch_user(user_id)
+                await econ.update_amount(user, amount, False, f"refunded bet on {option}")
+
+            value.clear()
+
+        await ctx.send("everyone has been refunded")
+
+    @commands.command()
+    @commands.is_owner()
+    async def disablebet(self, ctx):
+        """Disable the Bet"""
+        self.update_bet.cancel()
+        await ctx.send("Bet has been disabled.")
+
+    @commands.command()
+    @commands.is_owner()
+    async def resumebet(self, ctx):
+        """Resume a bet"""
+        self.update_bet.start()
+        await ctx.send("Bet has been resumed.")
+
+
+async def setup(client):
+    await client.add_cog(Betting(client))


### PR DESCRIPTION
incomplete betting cog

features:
- betting
- current bets displayed in an embed
- fancy buttons to make bet selection
- modal for inputting bet amount
- econ integration

TODO:
- persistence
- a nicer way of doing payouts
    - the current implementation is just a command with an integer index
    - the buttons could be repurposed when bets are disabled for this but that would be a bit unintuitive
    - showing a select box on command would be possible but would be shown to everyone 
- feedback to the user if they have won and how much
    - we cannot send ephemerals because there is no interaction
    - maybe DM the user if they won and how much
    - should the payout include the top 3 payouts?

<details>
<summary>some screenshots</summary>

![image](https://github.com/user-attachments/assets/f3f6bbde-05c9-4147-9bb8-85a3738bb501)

![image](https://github.com/user-attachments/assets/0e7842c6-7386-408c-90c6-e1f4255f3479)

![image](https://github.com/user-attachments/assets/904e82a9-e7f8-4f4c-9fa4-d775fcab4d0b)

![image](https://github.com/user-attachments/assets/90204e2a-3bbb-4b31-bbdb-6ba1494d4f8f)

![image](https://github.com/user-attachments/assets/04992a67-e89b-451a-9033-54d84a6001df)

</details>
