### PR TITLE
ensure excess balance fits into integer limit of history

### DIFF
--- a/utils/econfuncs.py
+++ b/utils/econfuncs.py
@@ -129,14 +129,18 @@ async def update_amount(
         new_balance = MAX_INT
         excess = bal + change - MAX_INT
         user_main.balance = new_balance
-        session.add(
-            models.economy.History(
-                user_id=user.id,
-                amount=excess,
-                reason=tracker_reason,
-                time=int(time.time()),
+
+        while excess > 0:
+            amount = min(MAX_INT, excess)
+            excess -= amount
+            session.add(
+                models.economy.History(
+                    user_id=user.id,
+                    amount=amount,
+                    reason=tracker_reason,
+                    time=int(time.time()),
+                )
             )
-        )
     else:
         user_main.balance = new_balance
         session.add(


### PR DESCRIPTION
economy related functions caused errors due to integer limits
```
Command raised an exception: OverflowError: Python int too large to convert to SQLite INTEGER
```
caused by the History table using integers instead of strings to store the balance.

New code splits the history into MAX_INT chunks so they can be stored without modifying the database.