### PR TITLE
make KittenTTS optional

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -21,11 +21,15 @@ import matplotlib.pyplot as plt
 from discord import FFmpegPCMAudio
 from discord.ext import commands, menus, tasks
 from discord.ui import Button, View
-from kittentts import KittenTTS
 from matplotlib.dates import DateFormatter
 from matplotlib.ticker import FuncFormatter
 from PIL import Image, ImageDraw, ImageFont
 from sqlalchemy import Integer, cast, delete, select, text
+
+try:
+    from kittentts import KittenTTS
+except ImportError:
+    KittenTTS = None
 
 import models
 import utils.achievements as ach
@@ -325,7 +329,9 @@ class Economy(commands.Cog):
         self.client = client
         self.award_map.add_exception_type(asyncpg.PostgresConnectionError)
         self.award_map.start()
-        self.kitten = KittenTTS("KittenML/kitten-tts-nano-0.1")
+
+        if KittenTTS is not None:
+            self.kitten = KittenTTS("KittenML/kitten-tts-nano-0.1")
 
     def cog_unload(self):
         self.award_map.cancel()
@@ -573,13 +579,15 @@ Example command: `,bougegram normal 100`"""
             "Go there and type join to join!"
         )
 
-        src = await audio.kitten_tts_source(
-            self.kitten,
-            announce,
-            voice="expr-voice-3-m",
-            concat_after_path="audio/madibanocaro.mp3",
-        )
-        vc.play(src)
+        if KittenTTS is not None:
+            src = await audio.kitten_tts_source(
+                self.kitten,
+                announce,
+                voice="expr-voice-3-m",
+                concat_after_path="audio/madibanocaro.mp3",
+            )
+            vc.play(src)
+
         while misc.get_unix() < end_check:
             try:
                 join_msg = await self.client.wait_for(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,19 @@ dependencies = [
     "alembic>=1.16.1",
     "numpy>=2.2.1",
     "aiohttp>=3.11.11",
+    "soundfile>=0.13.1",
     "mutagen>=1.47.0",
-    "kittentts",
     "pydub>=0.25.1",
 ]
 
 [dependency-groups]
 dev = [
     "ruff>=0.11.4",
+]
+
+[project.optional-dependencies]
+tts = [
+    "kittentts",
 ]
 
 [tool.uv]

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -8,9 +8,13 @@ import uuid
 import discord
 import numpy as np
 import soundfile as sf
-from kittentts import KittenTTS
 from mutagen import File as MutagenFile
 from pydub import AudioSegment
+
+try:
+    from kittentts import KittenTTS
+except ImportError:
+    KittenTTS = None
 
 
 class MixerAudioSource(discord.AudioSource):

--- a/uv.lock
+++ b/uv.lock
@@ -1261,7 +1261,6 @@ dependencies = [
     { name = "discord-py", extra = ["voice"] },
     { name = "emoji" },
     { name = "ffmpy" },
-    { name = "kittentts" },
     { name = "matplotlib" },
     { name = "mutagen" },
     { name = "numpy" },
@@ -1270,8 +1269,14 @@ dependencies = [
     { name = "pillow" },
     { name = "pydub" },
     { name = "pyquery" },
+    { name = "soundfile" },
     { name = "sqlalchemy", extra = ["aiosqlite"] },
     { name = "yfinance" },
+]
+
+[package.optional-dependencies]
+tts = [
+    { name = "kittentts" },
 ]
 
 [package.dev-dependencies]
@@ -1291,7 +1296,7 @@ requires-dist = [
     { name = "discord-py", extras = ["voice"], specifier = ">=2.6.3" },
     { name = "emoji", specifier = ">=2.14.1" },
     { name = "ffmpy", specifier = ">=0.5.0" },
-    { name = "kittentts", url = "https://github.com/KittenML/KittenTTS/releases/download/0.1/kittentts-0.1.0-py3-none-any.whl" },
+    { name = "kittentts", marker = "extra == 'tts'", url = "https://github.com/KittenML/KittenTTS/releases/download/0.1/kittentts-0.1.0-py3-none-any.whl" },
     { name = "matplotlib", specifier = ">=3.10.1" },
     { name = "mutagen", specifier = ">=1.47.0" },
     { name = "numpy", specifier = ">=2.2.1" },
@@ -1300,9 +1305,11 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.2.0" },
     { name = "pydub", specifier = ">=0.25.1" },
     { name = "pyquery", specifier = ">=2.0.1" },
+    { name = "soundfile", specifier = ">=0.13.1" },
     { name = "sqlalchemy", extras = ["aiosqlite"], specifier = ">=2.0.40" },
     { name = "yfinance", specifier = ">=0.2.55" },
 ]
+provides-extras = ["tts"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = ">=0.11.4" }]


### PR DESCRIPTION
KittenTTS pulls in many dependencies including the entire CUDA stack
```
blis
onnxruntime
spacy
nvidia-nvjitlink-cu12
nvidia-curand-cu12
nvidia-cuda-nvrtc-cu12
triton
nvidia-cufft-cu12
nvidia-cusolver-cu12
nvidia-cusparselt-cu12
nvidia-cusparse-cu12
nvidia-nccl-cu12
nvidia-cublas-cu12
nvidia-cudnn-cu12
torch
```
for development purposes this is overkill and not always appropriate so this PR turns it into an optional dependency