### PR TITLE
handle keyboard interrupt gracefully

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -100,5 +100,9 @@ async def on_ready():
 
 
 if __name__ == "__main__":
-    discord.utils.setup_logging()
-    asyncio.run(main())
+    try:
+        discord.utils.setup_logging()
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        # Handle gracefully
+        print("Stopping")


### PR DESCRIPTION
quitting the bot by doing Ctrl-C results in a useless traceback and a lot of noise
there is no point not to handle it gracefully and simply print an informative message

Will interfer with #157 